### PR TITLE
RF: Make --recording|-r mandatory

### DIFF
--- a/bin/sf-sort
+++ b/bin/sf-sort
@@ -10,7 +10,7 @@ from spikeforest2 import sorters
 def main():
     parser = argparse.ArgumentParser(description='Run spike sorting')
     parser.add_argument('--algorithm', '-a', help='Name of the algorithm to use: mountainsort4, ironclust, kilosort2, spykingcircus')
-    parser.add_argument('--recording', '-r', help='Path to the recording to sort')
+    parser.add_argument('--recording', '-r', help='Path to the recording to sort', required=True)
     parser.add_argument('--sorting_out', '-o', help='Optional path to the output sorting file', required=False, default=None)
     parser.add_argument('--cache', help='Optional cache to use: e.g., "local" if mongodb is installed.', required=False, default=None)
 


### PR DESCRIPTION
Otherwise running sf-sort without any option crashes with a traceback
instead of a useful message and/or --help output.

The bigger question on either --recording should not become a positional
argument and accept multiple files/urls

I would also vote to rename `--sorting-out` to just `--output` or alike. Since command is `sf-sort` anyways, the nature of output could be inferred ;)