### PR TITLE
Release tridesclous 1.6.0

### DIFF
--- a/spikeforest2/sorters/tridesclous/_tridesclous.py
+++ b/spikeforest2/sorters/tridesclous/_tridesclous.py
@@ -2,10 +2,10 @@ import os
 import random
 import hither_sf as hither
 
-@hither.function('tridesclous', '1.5.0')
+@hither.function('tridesclous', '1.6.0')
 @hither.output_file('sorting_out')
 #@hither.container(default='docker://magland/sf-tridesclous:1.4.3')
-@hither.container(default='docker://samuelgarcialyon/sf-tridesclous:1.5.0')
+@hither.container(default='docker://samuelgarcialyon/sf-tridesclous:1.6.0')
 @hither.local_module('../../../spikeforest2_utils')
 def tridesclous(
     recording_path,

--- a/spikeforest2/sorters/tridesclous/container/Dockerfile
+++ b/spikeforest2/sorters/tridesclous/container/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get install -y locales && locale-gen en_US.UTF-8
 RUN apt-get update && apt-get install -y libgl1-mesa-glx
 RUN pip install Cython
 RUN pip install scipy numpy pandas scikit-learn matplotlib seaborn tqdm openpyxl PyQt5==5.14.0 pyqtgraph==0.10 quantities neo numba hdbscan
-RUN pip install tridesclous==1.5.0
+RUN pip install tridesclous==1.6.0
 
 #########################################
 ## OpenCL/NVIDIA
@@ -32,5 +32,5 @@ RUN pip install pyopencl
 
 #########################################
 # python packages
-RUN pip install spikeextractors==0.7.1 spiketoolkit==0.5.1 spikesorters==0.2.3
-RUN pip install kachery==0.4.6
+RUN pip install spikeextractors==0.8.3 spiketoolkit==0.6.2 spikesorters==0.3.1
+RUN pip install kachery==0.4.13

--- a/spikeforest2/sorters/tridesclous/container/build_docker.sh
+++ b/spikeforest2/sorters/tridesclous/container/build_docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #docker build -t magland/sf-tridesclous:1.4.3 .
-docker build -t samuelgarcialyon/sf-tridesclous:1.5.0 .
+docker build -t samuelgarcialyon/sf-tridesclous:1.6.0 .

--- a/spikeforest2/sorters/tridesclous/container/push_docker.sh
+++ b/spikeforest2/sorters/tridesclous/container/push_docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # docker push magland/sf-tridesclous:1.4.3
-docker push samuelgarcialyon/sf-tridesclous:1.5.0
+docker push samuelgarcialyon/sf-tridesclous:1.6.0


### PR DESCRIPTION
Hi Jeremy.
here a patch for tridesclous 1.6.0
In this release there more opencl kernel that could bug.
Tell if it works.
I push the docker to my account.
I don't known you want to build your own.

Cheers
Samuel