### PR TITLE
Fix hard_links compatibility issue.

### DIFF
--- a/hither_sf/_run_function_in_container.py
+++ b/hither_sf/_run_function_in_container.py
@@ -122,6 +122,8 @@ def run_function_in_container(*,
                 except:
                     return
                 kachery_config = json.loads('{kachery_config_json}')
+                # delete newer use_hard_links key
+                kachery_config.pop("use_hard_links", None)
                 ka.set_config(**kachery_config)
 
             if __name__ == "__main__":


### PR DESCRIPTION
This removes a "use_hard_links" key from the kachery configuration dict passed to the kachery version running inside hither containers. Future changes may require further compatibility fixes, but I have confirmed that I can now run `examples/example_mountainsort4.py`.